### PR TITLE
Fixed Step 9 to direct users to frontend directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An application to track VWC applicant status
 6. copy/paste the `vwc_fng_tracker_schema.gql` file into the editor and save
 7. Click the 'Types' radio button, and add type entries for each type in 'types.gql'
 8. Navigate to the 'console' tab on ratel and select the 'Mutate' radio button. For each fle in the 'seeds' directory, copy/paste the text and hit the 'Run' button
-9. `cd` to `vwc_fng_tracker_be`
+9. `cd` to `vwc_fng_tracker_fe`
 10. run `yarn` to install dependencies
 11. run `yarn start` to start the FE application
 12. Contact Eddie to gain access to the google docs spreadsheet which contains applicant seed data. This should be downloaded as csv and imported through the applicant page's 'import csv' function (data will not show up immediately after import, page will need a refresh (this is a known bug)


### PR DESCRIPTION
### RELATED STORY ### 

None

### DESCRIPTION ### 

Current README.md directs new users to `vwc_fng_tracker_be` directory to execute `yarn` command.  The package.json file is in the `vwc_fng_tracker_fe` direction.

### STEPS TO REPRODUCE ISSUE ### 

NA  

### CHANGELIST ### 

- Updated README.md to direct users to correct directory to start frontend

### RESEARCH AND RESOURCES ### 

NA